### PR TITLE
归档页文章封面显示错误

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -55,7 +55,7 @@
                 <img class="w-100 h-100"
                      th:src="${theme.config.loading.preload}"
                      th:attr="onerror='this.src='+${'`'+theme.config.loading.err+'`'}"
-                     th:data-lazy-src="${post.spec.cover}+' '"
+                     th:data-lazy-src="${#strings.isEmpty(post.spec.cover) ? (random_img + '?index=' + postStat.index)  : post.spec.cover+' '}"
                      th:alt="${post.spec.title}" alt="">
               </a>
 


### PR DESCRIPTION
归档下文章若没有封面不会使用主题中设置好的封面
直接显示的是加载失败的图片
此处修改后就能使用设置好的封面了
![](https://user-images.githubusercontent.com/113070257/224775377-b6ef06b3-be68-4035-957b-d25d0c4dac03.png)
